### PR TITLE
Fix API hardcode

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -5,7 +5,8 @@ import meow from 'meow';
 import sass from 'gulp-sass';
 import babel from 'gulp-babel';
 import runSeq from 'run-sequence';
-import webpack from 'webpack-stream';
+import webpack from 'webpack';
+import webpackStream from 'webpack-stream';
 
 /*
  * NOTE: Ensure you have `gulp-cli` installed globally.
@@ -50,7 +51,7 @@ gulp.task('sass', () =>
 gulp.task('webpack', () =>
   gulp
     .src(`${sourcePath}/client/app.js`)
-    .pipe(webpack({
+    .pipe(webpackStream({
       devtool: debug ? 'inline-sourcemap' : null,
       entry: join(__dirname, `${sourcePath}/client/app.js`),
       output: {
@@ -69,6 +70,7 @@ gulp.task('webpack', () =>
         }],
       },
       plugins: debug ? [] : [
+        new webpack.EnvironmentPlugin(['NODE_ENV', 'PROTOCOL', 'HOST', 'PORT']),
         new webpack.optimize.DedupePlugin(),
         new webpack.optimize.OccurenceOrderPlugin(),
         new webpack.optimize.UglifyJsPlugin({ mangle: false, sourcemap: false }),

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "run-sequence": "^1.1.5",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
+    "webpack": "^1.13.1",
     "webpack-stream": "^3.2.0"
   },
   "dependencies": {

--- a/src/client/actions/index.js
+++ b/src/client/actions/index.js
@@ -1,5 +1,8 @@
 import * as types from '../constants/actionTypes';
 import Auth from '../services/AuthService';
+import { config } from '../config';
+
+const url = `${config.api.protocol}://${config.api.host}:${config.api.port}`;
 
 export const failedRequest = error => ({ type: types.ERR_FAILED_REQUEST, data: error });
 
@@ -22,7 +25,7 @@ export const receiveDecks = decks => ({ type: types.RECEIVE_DECKS, data: decks }
 export const selectDeck = deck => ({ type: types.SELECT_DECK, data: deck });
 export const fetchDecks = () => (
   dispatch => (
-    fetch('http://localhost:3000/api/decks', {
+    fetch(`${url}/api/decks`, {
       credentials: 'same-origin',
     })
     .then(res => res.json())
@@ -35,7 +38,7 @@ export const fetchCard = (deckId) => {
   const payload = JSON.stringify({ deckId });
 
   return dispatch => (
-    fetch('http://localhost:3000/api/card', {
+    fetch(`${url}/api/card`, {
       method: 'POST',
       headers: {
         'Content-type': 'application/json',
@@ -56,7 +59,7 @@ export const savePlay = (play, rating) => {
   const payload = JSON.stringify({ ...play, rating });
 
   return dispatch => (
-    fetch('http://localhost:3000/api/play', {
+    fetch(`${url}/api/play`, {
       method: 'POST',
       headers: {
         'Content-type': 'application/json',

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -47,7 +47,7 @@ render(
 );
 
 if (DEBUG) {
-  store.subscribe(() => process.stdout.write(store.getState()));
+  store.subscribe(() => console.log(store.getState()));
 }
 
 store.dispatch(verifyAuthentication());

--- a/src/client/components/DeckItem.js
+++ b/src/client/components/DeckItem.js
@@ -23,7 +23,7 @@ class DeckItem extends Component {
       .then(response => response.json())
       .then(play => {
         this.setState({
-          lastPlayedAt: play.createdAt,
+          lastPlayedAt: (play && play.createdAt) || '',
         });
       });
   }

--- a/src/client/config.js
+++ b/src/client/config.js
@@ -1,1 +1,9 @@
 export const DEBUG = false;
+
+export const config = {
+  api: {
+    protocol: process.env.PROTOCOL || 'http',
+    host: process.env.HOSTNAME || 'localhost',
+    port: process.env.PORT || 3000,
+  },
+};

--- a/src/client/config.js
+++ b/src/client/config.js
@@ -3,7 +3,7 @@ export const DEBUG = false;
 export const config = {
   api: {
     protocol: process.env.PROTOCOL || 'http',
-    host: process.env.HOSTNAME || 'localhost',
+    host: process.env.HOST || 'localhost',
     port: process.env.PORT || 3000,
   },
 };


### PR DESCRIPTION
Fixes #133 

This PR uses environment vars that a config file reads. Since `process.env` isn't available on the client side, webpack needed a new plugin.

How I tested:

``` bash
$ HOST=127.0.0.1 PORT=3333 PROTOCOL=http NODE_ENV=production npm run build:dist
$ HOST=127.0.0.1 PORT=3333 node ./dist/server/server.js
```

If this is not acceptable, an easy solution would be to change the source to use relative urls. That should be super easy. 
